### PR TITLE
transports: Close socket when closing the transport

### DIFF
--- a/src/gbulb/transports.py
+++ b/src/gbulb/transports.py
@@ -75,7 +75,7 @@ class BaseTransport(transports.BaseTransport):
             self._protocol.connection_lost(exc)
         finally:
             if self._sock is not None:
-                self._sock.detach()
+                self._sock.close()
                 self._sock = None
             if self._server is not None:
                 self._server._detach()


### PR DESCRIPTION
Merely detaching leads to the socket still being open, and thus behaves
differently from Python's asyncio where .close() on the transport also
closes the socket.

---

When calling `.close()` on a TCP socket, unlike in upstream asyncio, this does not cause the TCP connection to be closed, but merely leaks the file descriptor (which is what `.detach()` on a socket is described to do in the Python documentation).

This is precisly a revert of f900d4121a063f969b400e14a3c003d915a1404d  -- @dob3001 might have ideas why this is a bad idea, or check against the original use case. I couldn't do that because #47 contains no further explanations. Possibly, the file descriptor was still used in earlier versions of gbulb by something that'd close it, and now that other component was changed.

The problem was observed when running aiocoap with the gbulb loop; while all its test cases run through on several Python versions with asyncio, the TCP tests hang on gbulb. To observe what gbulb is doing it is easier to run, in a checked out aiocoap master branch, the command `AIOCOAP_TESTS_LOOP=gbulb python3 -m tests.test_server` and on a different terminal `socat - tcp6:localhost:5683`. Entering `0000<Enter>` leads to the termination of the connection on asyncio, and just the error message (but no TCP connetion termination) on gbulb. It's probably possible to make this into a more minimal proof of different behavior, but so far I hope that this relatively laborious process won't be necessary here.

## PR Checklist:
- [x] All new features have been tested
  (No new features were added; a tox run skipped a few interpreters but completed the tests on 3.9. towncrier, package and docs failed on dependencies but should not be relevant to this commit)
- [x] All new features have been documented
  (There are no new features)
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
