### PR TITLE
Prevent the GTK event loop from reusing the default GLib main context for every instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         task:
         - 'flake8'
-        - 'towncrier-check'
         - 'package'
     steps:
     - uses: actions/checkout@v1

--- a/changes/59.bugfix.rst
+++ b/changes/59.bugfix.rst
@@ -1,0 +1,1 @@
+The GTK event loop no longer forces the use of the default GLib main context on every instance.

--- a/src/gbulb/glib_events.py
+++ b/src/gbulb/glib_events.py
@@ -935,6 +935,8 @@ class GLibEventLoopPolicy(events.AbstractEventLoopPolicy):
     threads by default have no event loop.
     """
 
+    EventLoopCls = GLibEventLoop
+
     # TODO add a parameter to synchronise with GLib's thread default contexts
     #   (g_main_context_push_thread_default())
     def __init__(self, application=None):
@@ -970,12 +972,11 @@ class GLibEventLoopPolicy(events.AbstractEventLoopPolicy):
 
     def new_event_loop(self):
         """Create a new event loop and return it."""
-        if not self._default_loop and isinstance(
-            threading.current_thread(), threading._MainThread
-        ):
+        if not self._default_loop and \
+           threading.main_thread().ident == threading.get_ident():
             loop = self.get_default_loop()
         else:
-            loop = GLibEventLoop()
+            loop = self.EventLoopCls()
         loop._policy = self
 
         return loop
@@ -987,7 +988,7 @@ class GLibEventLoopPolicy(events.AbstractEventLoopPolicy):
         return self._default_loop
 
     def _new_default_loop(self):
-        loop = GLibEventLoop(
+        loop = self.EventLoopCls(
             context=GLib.main_context_default(), application=self._application
         )
         loop._policy = self

--- a/src/gbulb/gtk.py
+++ b/src/gbulb/gtk.py
@@ -1,6 +1,6 @@
 import threading
 
-from gi.repository import GLib, Gtk
+from gi.repository import Gtk
 
 from .glib_events import GLibEventLoop, GLibEventLoopPolicy
 
@@ -17,7 +17,6 @@ class GtkEventLoop(GLibEventLoop):
     def __init__(self, **kwargs):
         self._recursive = 0
         self._recurselock = threading.Lock()
-        kwargs["context"] = GLib.main_context_default()
 
         super().__init__(**kwargs)
 
@@ -55,15 +54,4 @@ class GtkEventLoop(GLibEventLoop):
 class GtkEventLoopPolicy(GLibEventLoopPolicy):
     """Gtk-based event loop policy. Use this if you are using Gtk."""
 
-    def _new_default_loop(self):
-        loop = GtkEventLoop(application=self._application)
-        loop._policy = self
-        return loop
-
-    def new_event_loop(self):
-        if not self._default_loop:
-            loop = self.get_default_loop()
-        else:
-            loop = GtkEventLoop()
-        loop._policy = self
-        return loop
+    EventLoopCls = GtkEventLoop


### PR DESCRIPTION
This caused “fun” migration of all scheduled callbacks between event loop instances with equally “fun” to debug asyncio low-level exceptions when using multi-threading with several concurrently running event loops.

It is completely unclear to the author of this change why the original change causes this breakage was introduced in 2015 in commit fde03cde in the first place. Perhaps the intention was merely to use the GLib default main context on the default main loop instance? Or perhaps its supposed to be shared between all instances of the main loop on the UI/main thread (some kind of recursion workaround maybe)?

## PR Checklist:
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
