### PR TITLE
Add support for Python 3.11/3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]  #, "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
     - uses: actions/checkout@v3.1.0
     - name: Set up Python ${{ matrix.python-version }}

--- a/changes/61.feature.rst
+++ b/changes/61.feature.rst
@@ -1,0 +1,1 @@
+Support for Python 3.11 and 3.12 was added.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    # Programming Language :: Python :: 3.11
-    # Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
 license = Apache 2.0
 license_file = LICENSE

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,7 +81,15 @@ def test_wait_signal(glib_loop):
         assert r == (t, "frozen brains tell no tales")
         called = True
 
-    glib_loop.run_until_complete(asyncio.wait([waiter(), emitter()], timeout=1))
+    glib_loop.run_until_complete(
+        asyncio.wait(
+            [
+                glib_loop.create_task(waiter()),
+                glib_loop.create_task(emitter()),
+            ],
+            timeout=1,
+        )
+    )
 
     assert called
 
@@ -122,7 +130,15 @@ def test_wait_signal_cancel(glib_loop):
         assert r.cancelled()
         cancelled = True
 
-    glib_loop.run_until_complete(asyncio.wait([waiter(), emitter()], timeout=1))
+    glib_loop.run_until_complete(
+        asyncio.wait(
+            [
+                glib_loop.create_task(waiter()),
+                glib_loop.create_task(emitter()),
+            ],
+            timeout=1,
+        )
+    )
 
     assert cancelled
     assert called


### PR DESCRIPTION
Updates to support Python 3.11 and 3.12:

* Adds the now-required SSL timeout parameters
* Modifies tests to use explicit tasks, rather than coroutines.
 
Fixes #61.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
