### PR TITLE
Add GitHub workflow to keep `pre-commit` hooks up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  min_python_version: "3.9"
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -61,6 +64,7 @@ jobs:
     - towncrier
     - package
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,12 @@
+name: Update pre-commit
+
+on:
+  schedule:
+    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
+  workflow_dispatch:
+
+jobs:
+  pre-commit-update:
+    name: Update pre-commit
+    uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
+    secrets: inherit

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,3 +10,5 @@ jobs:
     name: Update pre-commit
     uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
     secrets: inherit
+    with:
+      pre-commit-source: "pre-commit"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -9,27 +9,21 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
-    hooks:
-    - id: docformatter
-      args: [--in-place]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-eradicate==1.4.0]

--- a/changes/64.misc.rst
+++ b/changes/64.misc.rst
@@ -1,0 +1,1 @@
+A GitHub workflow now runs every Sunday at 2000 UTC to check for updates to ``pre-commit`` hooks and commits them to a new PR.


### PR DESCRIPTION
~~ Waiting on `flake8-eradicate` to be updated for `flake8>=6` ~~
~~- https://github.com/wemake-services/flake8-eradicate/pull/271~~

Updated `pre-commit` hooks and dropped support for `flake8-eradicate` due to extended incompatibility with `flake8==6.0.0`.

See beeware/.github#6 for details.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
