### PR TITLE
Add an explicit new_child_loop API

### DIFF
--- a/changes/61.feature.rst
+++ b/changes/61.feature.rst
@@ -1,1 +1,1 @@
-Support for Python 3.11 and 3.12 was added.
+Support for Python 3.11 was added.

--- a/changes/69.feature.rst
+++ b/changes/69.feature.rst
@@ -1,0 +1,1 @@
+Initial support for Python 3.12 was added.

--- a/src/gbulb/utils.py
+++ b/src/gbulb/utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import weakref
 
-__all__ = ["install", "get_event_loop", "wait_signal"]
+__all__ = ["install", "get_event_loop", "new_event_loop", "wait_signal"]
 
 
 def install(gtk=False):
@@ -39,6 +39,11 @@ def install(gtk=False):
 def get_event_loop():
     """Alias to asyncio.get_event_loop()."""
     return asyncio.get_event_loop()
+
+
+def new_event_loop():
+    """Alias to asyncio.new_event_loop()."""
+    return asyncio.new_event_loop()
 
 
 class wait_signal(asyncio.Future):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,7 +52,14 @@ def test_get_event_loop():
 
     import gbulb
 
-    assert asyncio.get_event_loop() is gbulb.get_event_loop()
+    try:
+        loop = gbulb.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        assert asyncio.get_event_loop() is gbulb.get_event_loop()
+
+    finally:
+        loop.close()
 
 
 def test_wait_signal(glib_loop):


### PR DESCRIPTION
Python 3.12a3 finalised the change to `get_child_loop()`; as a result, an explicit `new_child_loop()` API is required.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
