### PR TITLE
Use trusted publisher in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
     steps:
     - uses: actions/checkout@v3.5.2
 
@@ -27,8 +30,4 @@ jobs:
         tox -e package
 
     - name: Publish release
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        tox -e publish
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/changes/80.misc.rst
+++ b/changes/80.misc.rst
@@ -1,0 +1,1 @@
+Release processes were changed to use Trusted Publishing.

--- a/tox.ini
+++ b/tox.ini
@@ -38,13 +38,3 @@ commands =
     check-manifest -v
     python -m build --sdist --wheel --outdir dist
     python -m twine check dist/*
-
-[testenv:publish]
-deps =
-    wheel
-    twine
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-commands =
-    python -m twine upload dist/*


### PR DESCRIPTION
Adds the `id-token: write` permission to the publishing workflow to take advantage of trusted publishers. Also removes the `publish` tox task since it is no longer used.

Related to: https://github.com/beeware/beeware/issues/219

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
