### PR TITLE
Bump pre-commit-hooks from

### DIFF
--- a/update.log
+++ b/update.log
@@ -1,0 +1,1 @@
+[https://github.com/pre-commit/pre-commit-hooks] already up to date!


### PR DESCRIPTION
Bumps `pre-commit` hook for `pre-commit-hooks` from  and ran the update against the repo.