### PR TITLE
Bump black from

### DIFF
--- a/update.log
+++ b/update.log
@@ -1,0 +1,1 @@
+[https://github.com/psf/black] already up to date!


### PR DESCRIPTION
Bumps `pre-commit` hook for `black` from  and ran the update against the repo.