### PR TITLE
Bump flake8 from 6.0.0 to 6.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,6 @@ repos:
     - id: black
       language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8

--- a/changes/97.misc.rst
+++ b/changes/97.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``flake8`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `flake8` from 6.0.0 to 6.1.0 and ran the update against the repo.