### PR TITLE
Updated test suite to remove use of generators as co-routines.

### DIFF
--- a/changes/78.bugfix.rst
+++ b/changes/78.bugfix.rst
@@ -1,0 +1,1 @@
+Support for using a generator as a co-routine has been removed, in line with the change in behavior in Python 3.12. Python 3.11 and earlier will still support this usage, but it is no longer verified as part of GBulb.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,8 +76,7 @@ def test_wait_signal(glib_loop):
 
     t = TestObject()
 
-    def emitter():
-        yield
+    async def emitter():
         t.emit("foo", "frozen brains tell no tales")
 
     called = False
@@ -115,16 +114,16 @@ def test_wait_signal_cancel(glib_loop):
 
     t = TestObject()
 
-    def emitter():
-        yield
+    async def emitter():
         t.emit("foo", "frozen brains tell no tales")
 
     called = False
     cancelled = False
 
-    def waiter():
+    async def waiter():
         nonlocal cancelled
-        yield
+        # Yield to the event loop
+        await asyncio.sleep(0)
 
         r = wait_signal(t, "foo")
 


### PR DESCRIPTION
Python 3.12 removed support for using generators as co-routines. The test suite contained a couple of instances of this; this PR removes those usages.

No APIs have been changed, so generators should continue to work a co-routines on Python3.11; however, it would be generally advisable to update any existing code that is relying on this.

Fixes #78.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
