### PR TITLE
Bump pyupgrade from v3.13.0 to v3.15.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.13.0
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]

--- a/changes/107.misc.rst
+++ b/changes/107.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``pyupgrade`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `pyupgrade` from v3.13.0 to v3.15.0 and ran the update against the repo.