### PR TITLE
Bump codespell from v2.2.6 to v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       # remove toml extra once Python 3.10 is no longer supported

--- a/changes/144.misc.rst
+++ b/changes/144.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``codespell`` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `codespell` from v2.2.6 to v2.3.0 and ran the update against the repo.