### PR TITLE
Fix compatibility with Python 3.13

### DIFF
--- a/changes/176.bugfix.rst
+++ b/changes/176.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unix socket handling on Python 3.13

--- a/changes/176.bugfix.rst
+++ b/changes/176.bugfix.rst
@@ -1,1 +1,1 @@
-Fix unix socket handling on Python 3.13
+Unix socket handling was corrected to support changes in Python 3.13.

--- a/src/gbulb/glib_events.py
+++ b/src/gbulb/glib_events.py
@@ -201,6 +201,7 @@ else:
 
         def __init__(self):
             self._sighandlers = {}
+            self._unix_server_sockets = {}
 
         def close(self):
             for sig in list(self._sighandlers):

--- a/tests/test_glib_events.py
+++ b/tests/test_glib_events.py
@@ -590,9 +590,7 @@ def test_unix_sockets(glib_loop):
         writer.write(b"cool data\n")
         await writer.drain()
 
-        print("reading")
         d = await reader.readline()
-        print("hrm", d)
         server_success = d == b"thank you\n"
 
         writer.close()


### PR DESCRIPTION
_UnixSelectorEventLoop in Python 3.13 expect _unix_server_sockets dict, add one. It's later used (among others) in _stop_serving(), but not in close() directly, so just adding attribute is enough.

The related CPython change: 74b868f636a "gh-111246: Remove listening Unix socket on close (#111483)"

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
