### PR TITLE
Change one remaining _buffer_empty_callbacks to _drained_callbacks

### DIFF
--- a/changes/179.bugfix.rst
+++ b/changes/179.bugfix.rst
@@ -1,0 +1,1 @@
+``AttributeError: 'SocketTransport' object has no attribute '_buffer_empty_callbacks`` was fixed

--- a/src/gbulb/transports.py
+++ b/src/gbulb/transports.py
@@ -349,7 +349,7 @@ class SocketTransport(Transport):
                 if not self._closing:
                     self._sock.shutdown(socket.SHUT_WR)
 
-            self._buffer_empty_callbacks.add(transport_write_eof_callback)
+            self._drained_callbacks.add(transport_write_eof_callback)
 
 
 class DatagramTransport(Transport, transports.DatagramTransport):


### PR DESCRIPTION
Fixes: 74a3ec4 "Add support for driving `BufferedProtocol` instances using `sock_recv_into`"